### PR TITLE
Use s11 (gevb) instead of context stack

### DIFF
--- a/minivm.S
+++ b/minivm.S
@@ -26,8 +26,7 @@
 #define CONTEXT_r1312     0x28
 #define CONTEXT_r1110     0x30
 #define CONTEXT_gsp       0x40
-#define CONTEXT_gevb      0x44
-#define CONTEXT_gptb      0x48
+#define CONTEXT_gptb      0x44
 
 #define SSR_CAUSE_OFF        0
 #define SSR_CAUSE_WIDTH      8
@@ -581,7 +580,7 @@ MINIVM_common_user_push:
 	}
 	{
 		r11 = insert(r10, #2, #GUEST_CAUSE_IE_BIT)	// Insert UM:IE bits
-		r12 = memw(r24+#CONTEXT_gevb)
+		r12 = s11
 	}
 	r10 = elr
 	{
@@ -944,7 +943,7 @@ MINIVM_intop_clear:
 
 MINIVM_setvec: // r0=vector address
 	{
-		memw(r24+#CONTEXT_gevb) = r0
+		s11 = r0
 		r0 = #0
 		jump MINIVM_trap1_done
 	}

--- a/tests/first.S
+++ b/tests/first.S
@@ -30,7 +30,7 @@ angel_args:
 	.word   str
 	.word   6
 
-.align 8
+.p2align 8
 GUEST_event_vectors:
 	jump GUEST_event_abort           // 0: reserved`
 	jump GUEST_event_abort           // 1: machine check

--- a/tests/test_interrupts.S
+++ b/tests/test_interrupts.S
@@ -189,6 +189,7 @@ fail_args:
 	.word   fail_str
 	.word   6
 
+.p2align 8
 GUEST_event_vectors:
 	jump GUEST_event_abort           // 0: reserved
 	jump GUEST_event_abort           // 1: machine check

--- a/tests/test_mmu.S
+++ b/tests/test_mmu.S
@@ -92,6 +92,7 @@ _start:
 	vmstop
 
 
+.p2align 8
 GUEST_event_vectors:
 	jump GUEST_event_abort           // 0: reserved`
 	jump GUEST_event_abort           // 1: machine check

--- a/tests/test_processors.S
+++ b/tests/test_processors.S
@@ -124,6 +124,7 @@ fail_args:
 	.word   fail_str
 	.word   6
 
+.p2align 8
 GUEST_event_vectors:
 	jump GUEST_event_abort           // 0: reserved
 	jump GUEST_event_abort           // 1: machine check


### PR DESCRIPTION
Because gevb requires the low 8 bits to be zero, we align all the test cases' GUEST_event_vectors with ".p2align 8".