### PR TITLE
tests/test_processors: read the vmgettime predicate with .new

### DIFF
--- a/tests/test_processors.S
+++ b/tests/test_processors.S
@@ -59,7 +59,7 @@ _start:
 	r3:2 = #0xff
 	vmsettime
 	vmgettime
-	{ p0 = cmp.gtu(r1:0, r3:2); if (!p0) jump:nt _fail }
+	{ p0 = cmp.gtu(r1:0, r3:2); if (!p0.new) jump:nt _fail }
 
 	// Start a new virtual processor
 	r1 = ##(stack1 + STACK_SIZE - 8)


### PR DESCRIPTION
The vmsettime/vmgettime comparison wrote p0 and read it back in the same packet without .new, so the branch used the stale pre-packet p0 rather than the comparison it had just made and fell through to _fail regardless of the times returned.